### PR TITLE
FEAT: 카테고리 피드 페이지 API 연동 및 상태 필터 탭 구현

### DIFF
--- a/src/apis/categoryPost.ts
+++ b/src/apis/categoryPost.ts
@@ -1,0 +1,22 @@
+import { axiosInstance } from "./axios";
+import type { ResponseCategoryPostListDTO } from "../types/post"; 
+
+// 카테고리별 게시글 리스트 조회
+export const getPostListByCategoryId = async (
+  categoryId: number,
+  situation: string,
+  page: number = 0,
+  limit: number = 10
+): Promise<ResponseCategoryPostListDTO> => {
+  const { data } = await axiosInstance.get(
+    `/feeds/categories/${categoryId}/all`, 
+    {
+      params: { situation, page, limit },
+    }
+  );
+  return data;
+};
+
+
+
+

--- a/src/components/FeedPage/PostStatusTab.tsx
+++ b/src/components/FeedPage/PostStatusTab.tsx
@@ -1,22 +1,29 @@
+export type PostStatus = "OOPS" | "OVERCOMING" | "OVERCOME";
+
 type Props = {
-  selected: string;
-  onSelect: (status: string) => void;
+  selected: PostStatus;
+  onSelect: (status: PostStatus) => void;
 };
 
-const statuses = ["웁스 중", "극복 중", "극복 완료"];
+// 라벨과 API용 값 매핑
+const statuses: { label: string; value: PostStatus }[] = [
+  { label: "웁스 중", value: "OOPS" },
+  { label: "극복 중", value: "OVERCOMING" },
+  { label: "극복 완료", value: "OVERCOME" },
+];
 
 const PostStatusTab = ({ selected, onSelect }: Props) => {
   return (
     <div className="flex gap-[16px] mt-[18px] mb-[20px]">
       {statuses.map((status) => (
         <button
-          key={status}
-          onClick={() => onSelect(status)}
+          key={status.value}
+          onClick={() => onSelect(status.value)}
           className={`text-[14px] font-semibold px-[13px] py-[6.5px] rounded-[20px] ${
-            selected === status ? "bg-[#B3E378]" : "bg-[#E6E6E6]"
+            selected === status.value ? "bg-[#B3E378]" : "bg-[#E6E6E6]"
           }`}
         >
-          {status}
+          {status.label}
         </button>
       ))}
     </div>

--- a/src/pages/CategoryFeed.tsx
+++ b/src/pages/CategoryFeed.tsx
@@ -1,276 +1,63 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { getPostListByCategoryId } from "../apis/categoryPost";
+import type { Post } from "../types/post";
 import PostCard from "../components/common/PostCard";
 import PostStatusTab from "../components/FeedPage/PostStatusTab";
 import LeftArrow from "../assets/icons/left-point.svg?react";
-import { useParams } from "react-router-dom";
-import { useNavigate } from "react-router-dom";
-import { useState } from "react";
+import type { PostStatus } from "../components/FeedPage/PostStatusTab";
 
-const categoryMap: Record<string, string> = {
-  daily: "일상",
-  love: "연애",
-  relationship: "인간관계",
-  stock: "주식/투자",
-  school: "학교생활",
-  work: "회사생활",
-  career: "진로",
-  startup: "창업",
-  college: "대입/입시",
-  job: "취업/자격증",
-  marriage: "결혼",
-  travel: "여행",
-  realestate: "부동산",
-  mental: "정신건강",
-  free: "자유",
+const categoryData: Record<string, { id: number; label: string }> = {
+  daily: { id: 1, label: "일상" },
+  love: { id: 2, label: "연애" },
+  relationship: { id: 3, label: "인간관계" },
+  stock: { id: 4, label: "주식/투자" },
+  school: { id: 5, label: "학교생활" },
+  work: { id: 6, label: "회사생활" },
+  career: { id: 7, label: "진로" },
+  startup: { id: 8, label: "창업" },
+  college: { id: 9, label: "대입/입시" },
+  job: { id: 10, label: "취업/자격증" },
+  marriage: { id: 11, label: "결혼" },
+  travel: { id: 12, label: "여행" },
+  realestate: { id: 13, label: "부동산" },
+  mental: { id: 14, label: "정신건강" },
+  free: { id: 15, label: "자유" },
 };
-
-const mockPosts = [
-    {
-    id: 1,
-    title: "친구 사귀는 게 너무 어렵다",
-    content: "낯을 많이 가려서 다가가는 게 힘들어요.",
-    imageUrl: "",
-    likes: 8,
-    comments: 2,
-    views: 105,
-    category: "relationship",
-    status: "웁스 중",
-  },
-  {
-    id: 2,
-    title: "단체 생활이 너무 부담돼요",
-    content: "사람들과 계속 어울리는 게 피곤해요.",
-    imageUrl: "",
-    likes: 12,
-    comments: 3,
-    views: 133,
-    category: "relationship",
-    status: "웁스 중",
-  },
-  {
-    id: 3,
-    title: "친구가 내 말을 잘 안 들어줘요",
-    content: "계속 제 이야기를 무시당하는 느낌이에요.",
-    imageUrl: "",
-    likes: 9,
-    comments: 4,
-    views: 128,
-    category: "relationship",
-    status: "웁스 중",
-  },
-  {
-    id: 4,
-    title: "모임에서 소외되는 기분이에요",
-    content: "항상 마지막에 연락받고 혼자 있는 시간이 많아요.",
-    imageUrl: "",
-    likes: 11,
-    comments: 5,
-    views: 150,
-    category: "relationship",
-    status: "웁스 중"
-  },
-  {
-    id: 5,
-    title: "가식적인 인간관계에 지쳤어요",
-    content: "진심 없이 웃어주는 사람들과의 관계가 괴로워요.",
-    imageUrl: "",
-    likes: 14,
-    comments: 6,
-    views: 178,
-    category: "relationship",
-    status: "웁스 중"
-  },
-  {
-    id: 6,
-    title: "자꾸 사람 눈치를 보게 돼요",
-    content: "말 한마디에도 상처받을까 걱정돼요.",
-    imageUrl: "",
-    likes: 10,
-    comments: 2,
-    views: 122,
-    category: "relationship",
-    status: "웁스 중"
-  },
-
-  // 극복 중 (6개)
-  {
-    id: 7,
-    title: "조금씩 거리 두기를 연습 중이에요",
-    content: "모두와 친하지 않아도 괜찮다고 생각하려고요.",
-    imageUrl: "",
-    likes: 15,
-    comments: 4,
-    views: 160,
-    category: "relationship",
-    status: "극복 중"
-  },
-  {
-    id: 8,
-    title: "내 감정을 솔직하게 말해봤어요",
-    content: "예전엔 참기만 했는데 이제는 표현하려 해요.",
-    imageUrl: "",
-    likes: 13,
-    comments: 5,
-    views: 142,
-    category: "relationship",
-    status: "극복 중"
-  },
-  {
-    id: 9,
-    title: "거절을 배우고 있어요",
-    content: "싫은 걸 싫다고 말하는 연습을 하고 있어요.",
-    imageUrl: "",
-    likes: 17,
-    comments: 3,
-    views: 170,
-    category: "relationship",
-    status: "극복 중"
-  },
-  {
-    id: 10,
-    title: "친구들과의 소통이 조금씩 나아져요",
-    content: "천천히 서로 이해하는 시간을 가지려 해요.",
-    imageUrl: "",
-    likes: 16,
-    comments: 4,
-    views: 165,
-    category: "relationship",
-    status: "극복 중"
-  },
-  {
-    id: 11,
-    title: "억지로 맞추던 관계를 정리했어요",
-    content: "불편한 관계를 끊고 나니 마음이 편해졌어요.",
-    imageUrl: "",
-    likes: 19,
-    comments: 6,
-    views: 180,
-    category: "relationship",
-    status: "극복 중"
-  },
-  {
-    id: 12,
-    title: "속마음을 털어놓을 수 있는 친구가 생겼어요",
-    content: "혼자라는 생각이 조금 사라졌어요.",
-    imageUrl: "",
-    likes: 20,
-    comments: 5,
-    views: 192,
-    category: "relationship",
-    status: "극복 중"
-  },
-
-  // 극복 완료 (6개)
-  {
-    id: 13,
-    title: "진짜 친구가 누군지 알게 됐어요",
-    content: "힘든 시간 끝에 진심을 아는 사람이 남았어요.",
-    imageUrl: "",
-    likes: 25,
-    comments: 4,
-    views: 210,
-    category: "relationship",
-    status: "극복 완료"
-  },
-  {
-    id: 14,
-    title: "이젠 나다운 모습으로 지내요",
-    content: "억지로 맞추지 않고 있는 그대로 받아줘요.",
-    imageUrl: "",
-    likes: 22,
-    comments: 3,
-    views: 198,
-    category: "relationship",
-    status: "극복 완료"
-  },
-  {
-    id: 15,
-    title: "사람들과의 관계가 편해졌어요",
-    content: "이제는 대화가 즐겁고 부담이 없어요.",
-    imageUrl: "",
-    likes: 28,
-    comments: 6,
-    views: 230,
-    category: "relationship",
-    status: "극복 완료"
-  },
-  {
-    id: 16,
-    title: "내가 소중한 사람이란 걸 알았어요",
-    content: "존중받는 관계를 통해 나를 더 사랑하게 됐어요.",
-    imageUrl: "",
-    likes: 30,
-    comments: 7,
-    views: 245,
-    category: "relationship",
-    status: "극복 완료"
-  },
-  {
-    id: 17,
-    title: "불필요한 인간관계를 정리했어요",
-    content: "진짜 필요한 관계만 남기고 더 행복해졌어요.",
-    imageUrl: "",
-    likes: 27,
-    comments: 5,
-    views: 220,
-    category: "relationship",
-    status: "극복 완료"
-  },
-  {
-    id: 18,
-    title: "나도 좋은 친구가 될 수 있다는 걸 느껴요",
-    content: "서로 배려하는 관계가 이런 거구나 싶어요.",
-    imageUrl: "",
-    likes: 26,
-    comments: 4,
-    views: 215,
-    category: "relationship",
-    status: "극복 완료"
-  },
-
-  {
-    id: 7,
-    title: "사소한 실수로 민망했어요",
-    content: "엘리베이터 문 열렸는데 혼자 말하다 들켰어요 ㅠ",
-    imageUrl: "",
-    likes: 5,
-    comments: 2,
-    views: 55,
-    category: "small",
-    status: "웁스 중",
-  },
-  {
-    id: 8,
-    title: "썸 타던 사람이 갑자기 연락이 끊겼어요",
-    content: "왜인지 모르겠지만 너무 속상해요...",
-
-    likes: 12,
-    comments: 4,
-    views: 80,
-    category: "love",
-    status: "웁스 중",
-  },
-  {
-    id: 9,
-    title: "여행 가고 싶다",
-    content: "갑자기 훌쩍 떠나고 싶네요... 제주도?",
-
-    likes: 7,
-    comments: 1,
-    views: 73,
-    category: "travel",
-    status: "웁스 중",
-  },
-];
 
 const CategoryFeed = () => {
   const { categoryName } = useParams();
-  const displayName = categoryMap[categoryName ?? ""] ?? "알 수 없음";
   const navigate = useNavigate();
-  const [selectedStatus, setSelectedStatus] = useState("웁스 중");
 
-  const filteredPosts = mockPosts.filter(
-    (post) => post.category === categoryName && post.status === selectedStatus
-  );
+  const categoryInfo = categoryData[categoryName ?? ""];
+  const categoryId = categoryInfo?.id;
+  const displayName = categoryInfo?.label ?? "알 수 없음";
+
+  const [selectedStatus, setSelectedStatus] = useState<PostStatus>("OOPS");
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      if (!categoryId) {
+        console.warn("잘못된 카테고리입니다:", categoryName);
+        return;
+      }
+
+      setIsLoading(true);
+      try {
+        const res = await getPostListByCategoryId(categoryId, selectedStatus);
+        setPosts(res.result?.posts ?? []);
+      } catch (error) {
+        console.error("게시글 로딩 실패", error);
+        setPosts([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchPosts();
+  }, [categoryId, selectedStatus, categoryName]);
 
   return (
     <div className="w-full min-h-screen mx-auto bg-[#FFFBF8] pt-[17px] mb-[50px]">
@@ -280,19 +67,30 @@ const CategoryFeed = () => {
         </button>
         <h2 className="text-[20px] font-semibold">{displayName}</h2>
       </div>
+
       <PostStatusTab selected={selectedStatus} onSelect={setSelectedStatus} />
+
+
       <div className="flex flex-col gap-[12px] mt-[16px]">
-        {filteredPosts.map((post) => (
-          <PostCard
-            postId={post.id}
-            title={post.title}
-            content={post.content}
-            imageUrl={post.imageUrl}
-            likes={post.likes}
-            comments={post.comments}
-            views={post.views}
-          />
-        ))}
+        {isLoading ? (
+          <p className="text-center">로딩 중...</p>
+        ) : posts.length === 0 ? (
+          <p className="text-center text-sm text-gray-400">게시글이 없습니다.</p>
+        ) : (
+          posts.map((post) => (
+            <PostCard
+              key={post.postId}
+              postId={post.postId}
+              title={post.title}
+              content={post.content}
+              imageUrl={post.image ?? ""}
+              likes={post.likes}
+              comments={post.comments}
+              views={post.views}
+              category={post.categoryName}
+            />
+          ))
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## 기능
- 카테고리 이름에 따른 피드 목록을 API로 불러오도록 구현
- '웁스 중 / 극복 중 / 극복 완료' 상태별 필터 탭 추가

##  주요 변경 사항
- `CategoryFeed.tsx`: 카테고리 이름과 상태에 따라 게시글 목록 조회
- `PostStatusTab.tsx`: 상태 필터 UI 컴포넌트 구현 및 선택 기능 추가
- `categoryPost.ts`: 카테고리별 게시글 조회 API 함수 정의

## 테스트 
- `/category/:categoryName` 라우트에서 정상 작동 확인
- 상태 탭 클릭 시 게시글 목록 필터링 되는지 확인

