### PR TITLE
[feat]Auth Context 생성 및 로그인 전후 반영

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,7 @@ import LuckyDraw from "./pages/LuckyDrawPage/LuckyDraw";
 import PostWriteLayout from "./layout/PostWriteLayout";
 import FailWiki from "./pages/FailWiki";
 import { AuthProvider } from "./context/AuthContext";
+import ProtectedLayout from "./layout/ProtectedLayout";
 
 function App() {
   //userId가 필요해서 꺼내 쓰기 위해 최상위 폴더에서 useEffect활용
@@ -72,6 +73,65 @@ function App() {
         { path: "random-feed", element: <RandomFeed /> },
         { path: "best-feed", element: <BestFeed /> },
         { path: "exrandom-feed", element: <ExRandomFeed /> },
+        // { path: "postsuccess", element: <PostSuccess /> },
+        // { path: "post/:postId", element: <PostDetail /> },
+        // { path: "drawer", element: <CategoryDrawerTest /> },
+        // { path: "fail-wiki", element: <FailWiki /> },
+        // {
+        //   path: "/lucky-draw",
+        //   element: (
+        //     <ProtectedRoute>
+        //       <LuckyDraw />
+        //     </ProtectedRoute>
+        //   ),
+        // },
+      ],
+    },
+
+    {
+      path: "/mypage",
+      element: (
+        <ProtectedRoute>
+          <MyPageLayout />
+        </ProtectedRoute>
+      ),
+      children: [
+        { index: true, element: <Navigate to="failures" replace /> },
+        { path: "failures", element: <MyFailuresPage /> },
+        { path: "lessons", element: <MyLessonsPage /> },
+        { path: "profile", element: <MyProfilePage /> },
+      ],
+    },
+
+    // {
+    //   path: "/post",
+    //   element: (
+    //     <ProtectedRoute>
+    //       <PostWriteLayout />
+    //     </ProtectedRoute>
+    //   ),
+    //   children: [{ index: true, element: <PostWrite /> }],
+    // },
+
+    // {
+    //   path: "/users/:userId",
+    //   element: <OthersProfilePage />,
+    // },
+
+    { path: "/signin", element: <SigninPage /> },
+    { path: "/signup", element: <SignupPage /> },
+    { path: "/find-idpw", element: <FindIdPwPage /> },
+    { path: "/terms", element: <TermsPage /> },
+    { path: "/search", element: <SearchPage /> },
+  ];
+
+  //여기에 portextedroute로 넣어주시면 됩니당...
+  const protectedRoutes: RouteObject[] = [
+    {
+      path: "/",
+      element: <ProtectedLayout />,
+      errorElement: <div>Not Found</div>,
+      children: [
         { path: "postsuccess", element: <PostSuccess /> },
         { path: "post/:postId", element: <PostDetail /> },
         // { path: "drawer", element: <CategoryDrawerTest /> },
@@ -116,15 +176,9 @@ function App() {
       path: "/users/:userId",
       element: <OthersProfilePage />,
     },
-
-    { path: "/signin", element: <SigninPage /> },
-    { path: "/signup", element: <SignupPage /> },
-    { path: "/find-idpw", element: <FindIdPwPage /> },
-    { path: "/terms", element: <TermsPage /> },
-    { path: "/search", element: <SearchPage /> },
   ];
 
-  const router = createBrowserRouter([...publicRoutes]);
+  const router = createBrowserRouter([...publicRoutes, ...protectedRoutes]);
 
   return (
     <AuthProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,7 @@ import OthersProfilePage from "./pages/OthersProfilePage";
 import LuckyDraw from "./pages/LuckyDrawPage/LuckyDraw";
 import PostWriteLayout from "./layout/PostWriteLayout";
 import FailWiki from "./pages/FailWiki";
+import { AuthProvider } from "./context/AuthContext";
 
 function App() {
   //userId가 필요해서 꺼내 쓰기 위해 최상위 폴더에서 useEffect활용
@@ -126,9 +127,11 @@ function App() {
   const router = createBrowserRouter([...publicRoutes]);
 
   return (
-    <Provider store={store}>
-      <RouterProvider router={router} />
-    </Provider>
+    <AuthProvider>
+      <Provider store={store}>
+        <RouterProvider router={router} />
+      </Provider>
+    </AuthProvider>
   );
 }
 

--- a/src/apis/auth/authApi.ts
+++ b/src/apis/auth/authApi.ts
@@ -1,9 +1,15 @@
+import type { User } from "../../types/User";
 import instance from "../instance";
 import Cookies from "js-cookie";
 
-type LoginResult =
-  | { accessToken: string; refreshToken?: string; userId?: string | number }
-  | string;
+type LoginResult = {
+  accessToken: string;
+  refreshToken?: string;
+  userId: number;
+  nickName: string;
+  email: string;
+  profileImage: string | null;
+};
 
 export type TermsAgreementItem = {
   termId: number;
@@ -39,14 +45,37 @@ export const postLogin = async ({
   const result: LoginResult = res.data?.result;
   let accessToken = "";
   let refreshToken = "";
-  let userId: string | number | undefined;
+  let user: User = {
+    userId: result.userId,
+    nickname: result.nickName,
+    email: result.email,
+    profileImage: result.profileImage,
+  };
 
-  if (typeof result === "string") {
-    accessToken = result;
-  } else if (result && typeof result === "object") {
-    accessToken = result.accessToken;
-    refreshToken = result.refreshToken ?? "";
-    userId = result.userId;
+  //이부분 무조건 객체러 넘어와서 string 부분 빼고 object만 구현할게요! (예은)
+
+  // if (typeof result === "string") {
+  //   accessToken = result;
+  // } else if (result && typeof result === "object") {
+  //   accessToken = result.accessToken;
+  //   refreshToken = result.refreshToken ?? "";
+  //   user = result.
+  // }
+
+  if (result) {
+    //result 객체 분해할당 -> user 데이터 넣을려고!
+    const {
+      accessToken: at,
+      refreshToken: rt = "",
+      userId,
+      nickName: nickname,
+      email,
+      profileImage,
+    } = result;
+
+    accessToken = at;
+    refreshToken = rt;
+    user = { userId, nickname, email, profileImage };
   }
 
   if (!accessToken) {
@@ -56,8 +85,8 @@ export const postLogin = async ({
   //const token = res.data.result;
   localStorage.setItem("accessToken", accessToken);
   if (refreshToken) localStorage.setItem("refreshToken", refreshToken);
-  if (userId !== undefined) localStorage.setItem("userId", String(userId));
-
+  localStorage.setItem("userId", String(user.userId));
+  localStorage.setItem("profileImage", user.profileImage ?? "");
   // Cookies.set("AccessToken", `Bearer+${accessToken}`, {
   //   path: "/",
   // });

--- a/src/apis/post.ts
+++ b/src/apis/post.ts
@@ -5,11 +5,16 @@ import type {
 } from "../types/post";
 import { axiosInstance } from "./axios";
 
-
-
 export const getPostListInMainPage =
   async (): Promise<ResponseMainPostListDTO> => {
     const { data } = await axiosInstance.get("/feeds/home/first-auth");
+    console.log(data);
+    return data;
+  };
+
+export const getPostListInMainPagetoGuest =
+  async (): Promise<ResponseMainPostListDTO> => {
+    const { data } = await axiosInstance.get("/feeds/home/first-guest");
     console.log(data);
     return data;
   };

--- a/src/components/common/BestFailerTitleList.tsx
+++ b/src/components/common/BestFailerTitleList.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import useGetPostListInMain from "../../hooks/MainPage/UseGetPostList";
+import useGetPostListInMain from "../../hooks/MainPage/useGetAuthPostList";
 
 type TitleLike = { title?: string; name?: string };
 

--- a/src/components/common/Navbar.tsx
+++ b/src/components/common/Navbar.tsx
@@ -6,10 +6,11 @@ import My from "../../assets/icons/my.svg?react";
 import { useState } from "react";
 import CategoryDrawer from "../common/CategoryDrawer";
 import { Link } from "react-router-dom";
+import { useAuth } from "../../context/AuthContext";
 
 const Navbar = () => {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
-
+  const { accessToken, user } = useAuth();
   return (
     <>
       <nav className="flex justify-between items-center px-[20px] py-[12px] bg-[#FFF] border-neutral-700 shadow-[0px_1px_4px_0px_rgba(0,0,0,0.05)]">
@@ -22,20 +23,44 @@ const Navbar = () => {
             <Logo className="w-[49.498px] h-[20px]" />
           </Link>
         </div>
+        {!accessToken && (
+          <div className="flex gap-[8px] items-center">
+            <Link to="/signin">
+              <SearchLogo />
+            </Link>
 
-        <div className="flex gap-[8px] items-center">
-          <Link to="search">
-            <SearchLogo />
-          </Link>
+            <Link to="/signin">
+              <WriteLogo />
+            </Link>
 
-          <Link to="/post">
-            <WriteLogo />
-          </Link>
+            <Link to="/signin">
+              <My />
+            </Link>
+          </div>
+        )}
+        {accessToken && (
+          <div className="flex gap-[8px] items-center">
+            <Link to="/search">
+              <SearchLogo />
+            </Link>
 
-          <Link to="/mypage">
-            <My />
-          </Link>
-        </div>
+            <Link to="/post">
+              <WriteLogo />
+            </Link>
+
+            <Link to="/mypage">
+              {user?.profileImage ? (
+                <img
+                  src={user.profileImage}
+                  alt="프로필"
+                  className="w-6 h-6 rounded-full object-cover"
+                />
+              ) : (
+                <div className="w-6 h-6 rounded-full bg-gray-300" />
+              )}
+            </Link>
+          </div>
+        )}
       </nav>
 
       {/* 드로어 조건부 렌더링 */}

--- a/src/components/mainPage/MainFeedList.tsx
+++ b/src/components/mainPage/MainFeedList.tsx
@@ -1,13 +1,34 @@
-import useGetPostListInMain from "../../hooks/MainPage/UseGetPostList";
+import { useAuth } from "../../context/AuthContext";
+import useGetAuthPostListInMain from "../../hooks/MainPage/useGetAuthPostList";
+import useGetGuestPostListInMain from "../../hooks/MainPage/useGetGuestPostList";
 import useGetPostLIstCategory from "../../hooks/MainPage/useGetPostListCategory";
 import BestFailerList from "./BestFailerList";
 import CategoryList from "./CategoryList";
 import FavoritesCategoryList from "./FavoritesCategoryList";
 
 const MainFeedList = () => {
-  const { posts, mainLoading, mainError } = useGetPostListInMain();
+  const { accessToken } = useAuth();
+  const isAuthed = !!accessToken;
+
+  // 훅은 항상 호출
+  const {
+    posts: authedPosts,
+    mainLoading: authedLoading,
+    mainError: authedError,
+  } = useGetAuthPostListInMain();
+
+  const {
+    posts: guestPosts, // ← useGetGuestPostListInMain이 posts를 반환하도록 맞춰주세요 (post → posts 오타 주의)
+    mainLoading: guestLoading,
+    mainError: guestError,
+  } = useGetGuestPostListInMain();
+
   const { categoryPosts, categoryLoading, categoryError } =
     useGetPostLIstCategory();
+
+  const posts = isAuthed ? authedPosts : guestPosts;
+  const mainLoading = isAuthed ? authedLoading : guestLoading;
+  const mainError = isAuthed ? authedError : guestError;
 
   if (mainLoading || categoryLoading) return <div>로딩중...</div>;
   if (mainError || categoryError) return <div>에러남.</div>;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,97 @@
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  type PropsWithChildren,
+} from "react";
+import { postLogin } from "../apis/auth/authApi";
+import type { User } from "../types/User";
+
+type LoginParams = { email: string; password: string };
+
+interface AuthContextType {
+  user: User | null;
+  accessToken: string | null;
+  refreshToken: string | null;
+  login: (params: LoginParams) => Promise<void>;
+}
+
+const ACCESS_TOKEN_KEY = "accessToken";
+const REFRESH_TOKEN_KEY = "refreshToken";
+const USER_KEY = "user";
+
+export const AuthContext = createContext<AuthContextType>({
+  user: null,
+  accessToken: null,
+  refreshToken: null,
+  login: async () => {
+    throw new Error("AuthProvider가 설정되지 않았습니다.");
+  },
+});
+
+export const AuthProvider = ({ children }: PropsWithChildren) => {
+  // lazy initializer로 처음 한 번만 localStorage 읽기 -> usestate로 읽었더니 에러가 와라라라 나가지고 바꿨습니다.ㅇ.ㅠㅠ
+  const [accessToken, setAccessToken] = useState<string | null>(() =>
+    localStorage.getItem(ACCESS_TOKEN_KEY)
+  );
+  const [refreshToken, setRefreshToken] = useState<string | null>(() =>
+    localStorage.getItem(REFRESH_TOKEN_KEY)
+  );
+  const [user, setUser] = useState<User | null>(() => {
+    const raw = localStorage.getItem(USER_KEY);
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw) as User;
+    } catch {
+      return null;
+    }
+  });
+
+  const login = async (signinData: LoginParams) => {
+    try {
+      const { data } = await postLogin(signinData);
+
+      if (!data) throw new Error("로그인 응답이 없습니다.");
+
+      const newAccessToken = data.accessToken as string;
+      const newRefreshToken = data.refreshToken as string;
+
+      // 서버 키가 nickName / nickname 혼용될 수 있어 보호적으로 처리
+      const nickname = data.nickname ?? data.nickName;
+
+      const newUser: User = {
+        userId: Number(data.userId),
+        nickname,
+        email: String(data.email),
+        profileImage: data.profileImage ?? null,
+      };
+
+      // 1) state
+      setAccessToken(newAccessToken);
+      setRefreshToken(newRefreshToken);
+      setUser(newUser);
+
+      // 2) storage
+      localStorage.setItem(ACCESS_TOKEN_KEY, newAccessToken);
+      localStorage.setItem(REFRESH_TOKEN_KEY, newRefreshToken);
+      localStorage.setItem(USER_KEY, JSON.stringify(newUser));
+
+      // 라우팅은 Provider 밖(페이지)에서 navigate로 처리 추천
+      // ex) 로그인 페이지에서: await login(...); navigate("/");
+    } catch (error) {
+      console.error("Login failed", error);
+      throw error; // 호출한 쪽에서 에러 UI 처리
+    }
+  };
+
+  // value는 메모이즈해서 불필요 리렌더 방지
+  const value = useMemo<AuthContextType>(
+    () => ({ accessToken, refreshToken, user, login }),
+    [accessToken, refreshToken, user]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/src/hooks/MainPage/useGetAuthPostList.ts
+++ b/src/hooks/MainPage/useGetAuthPostList.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { getPostListInMainPage } from "../../apis/post";
 import type { ResponseMainPostListDTO } from "../../types/post";
 
-function useGetPostListInMain() {
+function useGetAuthPostListInMain() {
   const [posts, setPosts] = useState<ResponseMainPostListDTO | null>(null);
   const [mainLoading, setLoading] = useState(true);
   const [mainError, setError] = useState<string | null>(null);
@@ -25,4 +25,4 @@ function useGetPostListInMain() {
   return { posts, mainLoading, mainError };
 }
 
-export default useGetPostListInMain;
+export default useGetAuthPostListInMain;

--- a/src/hooks/MainPage/useGetGuestPostList.ts
+++ b/src/hooks/MainPage/useGetGuestPostList.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import { getPostListInMainPagetoGuest } from "../../apis/post";
+import type { ResponseMainPostListDTO } from "../../types/post";
+
+function useGetGuestPostListInMain() {
+  const [posts, setPosts] = useState<ResponseMainPostListDTO | null>(null);
+  const [mainLoading, setLoading] = useState(true);
+  const [mainError, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const data = await getPostListInMainPagetoGuest(); // data.data 반환
+        setPosts(data);
+      } catch (err) {
+        setError("게시글 불러오기 실패");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  return { posts, mainLoading, mainError };
+}
+
+export default useGetGuestPostListInMain;

--- a/src/hooks/WikiPage/useGetFailWiki.ts
+++ b/src/hooks/WikiPage/useGetFailWiki.ts
@@ -10,7 +10,8 @@ function useGetFailWiki() {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const data = await getCurrentWikis(); // data.data 반환
+        const data = await getCurrentWikis();
+        console.log(data);
         setWikis(data);
       } catch (err) {
         setError("위키 불러오기 실패");

--- a/src/layout/HomeLayout.tsx
+++ b/src/layout/HomeLayout.tsx
@@ -1,8 +1,15 @@
-import { Outlet, useLocation } from "react-router-dom";
+import { Navigate, Outlet, useLocation } from "react-router-dom";
 import Navbar from "../components/common/Navbar";
 import Footer from "../components/common/Footer";
+import { useAuth } from "../context/AuthContext";
 
 const HomeLayout = () => {
+  const { accessToken } = useAuth();
+
+  if (!accessToken) {
+    return <Navigate to={"/signin"} replace />;
+  }
+
   const location = useLocation();
   const isFooterHidden = location.pathname === "/lucky-draw";
 

--- a/src/layout/ProtectedLayout.tsx
+++ b/src/layout/ProtectedLayout.tsx
@@ -1,8 +1,14 @@
-import { Outlet, useLocation } from "react-router-dom";
+import { Navigate, Outlet, useLocation } from "react-router-dom";
 import Navbar from "../components/common/Navbar";
 import Footer from "../components/common/Footer";
+import { useAuth } from "../context/AuthContext";
 
-const HomeLayout = () => {
+const ProtectedLayout = () => {
+  const { accessToken } = useAuth();
+
+  if (!accessToken) {
+    return <Navigate to={"/signin"} replace />;
+  }
   const location = useLocation();
   const isFooterHidden = location.pathname === "/lucky-draw";
 
@@ -19,4 +25,4 @@ const HomeLayout = () => {
   );
 };
 
-export default HomeLayout;
+export default ProtectedLayout;

--- a/src/pages/FailWiki.tsx
+++ b/src/pages/FailWiki.tsx
@@ -6,7 +6,7 @@ import WikiKeyword from "../components/FailWiki/WikiKeyword";
 import WikiBestFailerList from "../components/FailWiki/WikiBestFailerList";
 import WikiResultCard from "../components/FailWiki/WIkiResultCard";
 import { getFailWikiResult } from "../apis/wiki";
-import type { ResponseWikiSearch } from "../types/wkik";
+import type { wikiTips } from "../types/wkik";
 import { categoryMap } from "../types/common";
 import { Link } from "react-router-dom";
 import useGetFailWiki from "../hooks/WikiPage/useGetFailWiki";
@@ -14,7 +14,7 @@ import useGetFailWiki from "../hooks/WikiPage/useGetFailWiki";
 const FailWiki = () => {
   const { wiki, loading, error } = useGetFailWiki();
   const [inputValue, setInputValue] = useState("");
-  const [resultList, setResultList] = useState<ResponseWikiSearch | null>(null);
+  const [resultList, setResultList] = useState<wikiTips | null>(null);
 
   if (loading) return <div>로딩중...</div>;
   if (error) return <div>에러남.</div>;
@@ -24,7 +24,7 @@ const FailWiki = () => {
     try {
       if (value.trim() !== "") {
         const data = await getFailWikiResult({ keyword: value });
-        setResultList(data);
+        setResultList(data.result);
       }
     } catch (error) {
       console.log("실패위키 검색 실패", error);
@@ -80,7 +80,7 @@ const FailWiki = () => {
                 />
               </div>
               <div className="grid grid-cols-2 justify-items-start gap-y-[10px]">
-                {wiki?.slice(0, 4).map((item, idx) => (
+                {wiki?.result.slice(0, 4).map((item, idx) => (
                   <div
                     key={idx}
                     className={

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,0 +1,6 @@
+export type User = {
+  userId: number;
+  nickname?: string;
+  email?: string;
+  profileImage?: string | null;
+};

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -2,7 +2,7 @@ export type CommonResponse<T> = {
   isSuccess: boolean;
   code: string;
   message: string;
-  result?: T;
+  result: T;
 };
 
 export type SearchParams = {

--- a/src/types/wkik.ts
+++ b/src/types/wkik.ts
@@ -1,12 +1,7 @@
+import type { CommonResponse } from "./common";
 import type { BestFailers } from "./post";
 
-export type ResponseWikiSearch = {
-  keyword: string;
-  summary: string;
-  aiTip: string;
-  postCount: number;
-  bestFailers: BestFailers[];
-};
+export type ResponseWikiSearch = CommonResponse<wikiTips>;
 
 type wiki = {
   keyword: string;
@@ -16,4 +11,12 @@ type wiki = {
   modifiedAt: string;
 };
 
-export type ResponseCurrentWiki = wiki[];
+export type wikiTips = {
+  keyword: string;
+  summary: string;
+  aiTip: string;
+  postCount: number;
+  bestFailers: BestFailers[];
+};
+
+export type ResponseCurrentWiki = CommonResponse<wiki[]>;


### PR DESCRIPTION
## 작업 내용
AuthContext.tsx파일에서 사용자 정보를 전역으로 관리 -> 이때 <AuthProvider>로 app.tsx에서 라우터 관리
AuthContext.tsx 파일 잘 읽어서 refreshtoken 구현도 해당 파일에서 구현하면 될거 같습니다!
주석 조금 적어둠

회의때 로그인 전후 리스트 확실히 받아서 api에서 인증 필요없이 데이터 받아올 수 있도록 해야할 것 같습니다.

로그인 전후에 맞춰서 nav,매인페이지 구현 완료 (로그인 전에 메인페이지 렌더링 안되는건 later api가 인증을 필요로 하기 때문 -> 추가 api 필요)

## 체크리스트
- [x] UI 구현
- [x] API 연동
- [x] 에러 처리
- [ ] 테스트 완료
## 관련 
Fixes #103 